### PR TITLE
Update commons-validator to 1.7 to resolve CVE in commons-beanutils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.ihtsdo.snomed.util</groupId>
 	<artifactId>snomed-utilities</artifactId>
-	<version>1.4.1</version>
+	<version>1.4.2</version>
 	<name>SNOMED CT Utilities</name>
 
 	<licenses>
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>commons-validator</groupId>
 			<artifactId>commons-validator</artifactId>
-			<version>1.5.1</version>
+			<version>1.7</version>
 		</dependency>
 		<!-- Logging -->
 		<dependency>


### PR DESCRIPTION
The version of commons-validator this library is depending on uses a version of commons-beanutils which has a high severity CVE against it - CVE-2019-10086.

This is a simple minimalist update to work around this issue. There are other dependencies that should probably also be updated (see `mvn versions:display-dependency-updates` for more details) but to keep this pull request simple I've not addressed those.